### PR TITLE
playfab: remove common parameters in function calls

### DIFF
--- a/noop_logger.go
+++ b/noop_logger.go
@@ -1,0 +1,8 @@
+package playfab
+
+type noopLogger struct{}
+
+func (*noopLogger) Debug(format string, v ...interface{}) {}
+func (*noopLogger) Info(format string, v ...interface{})  {}
+func (*noopLogger) Warn(format string, v ...interface{})  {}
+func (*noopLogger) Error(format string, v ...interface{}) {}


### PR DESCRIPTION
Add a constructor to accept secret,titleId, catalog version and an optional logger.

Also, re-use http.Client among all requests and add defaults.